### PR TITLE
esp-idf v5 compilation

### DIFF
--- a/main/nimble.c
+++ b/main/nimble.c
@@ -167,9 +167,9 @@ void startBLE() //! Call this function to start BLE
 
   ESP_ERROR_CHECK(ret);
 
-  ESP_ERROR_CHECK(esp_nimble_hci_and_controller_init());
+  ESP_ERROR_CHECK(nimble_port_init());
+  ESP_ERROR_CHECK(esp_nimble_hci_init());
 
-  nimble_port_init();
   /* Initialize the NimBLE host configuration. */
   ble_hs_cfg.reset_cb = bleprph_on_reset;
   ble_hs_cfg.sync_cb = bleprph_on_sync;
@@ -216,7 +216,7 @@ void stopBLE() //! Call this function to stop BLE
   {
     nimble_port_deinit();
 
-    ret = esp_nimble_hci_and_controller_deinit();
+    ret = esp_nimble_hci_deinit();
     if (ret != ESP_OK)
     {
       ESP_LOGE(tag, "esp_nimble_hci_and_controller_deinit() failed with error: %d", ret);


### PR DESCRIPTION
I couldn't get it to compile at v5.1 of the esp-idf. It seems there has been a change in v5 regarding initializing nimble.

https://github.com/espressif/esp-idf/releases/tag/v5.0-rc1
Breaking changes -> Bluetooth

It now compiles and runs/tested it with chrome. I have not looked at other changes that might have happened when going from v4 to v5